### PR TITLE
ENH: Update to newest version of bids-client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # curate-bids
 
-FROM flywheel/bids-client:0.9.0
+FROM flywheel/bids-client:0.9.1
 MAINTAINER Flywheel <support@flywheel.io>
 
 # Install JQ to parse config file

--- a/manifest.json
+++ b/manifest.json
@@ -6,11 +6,11 @@
   "maintainer": "Flywheel <support@flywheel.io>",
   "source": "https://github.com/flywheel-apps/curate-bids",
   "url": "http://bids.neuroimaging.io/",
-  "version": "1.0.0_0.9.0",
+  "version": "1.0.0_0.9.1",
   "custom": {
       "gear-builder": {
            "category": "converter",
-           "image": "flywheel/curate-bids:1.0.0_0.9.0"
+           "image": "flywheel/curate-bids:1.0.0_0.9.1"
       },
       "flywheel": {
           "suite": "BIDS"


### PR DESCRIPTION
This version fixes the ignore-BIDS regex so that it bids import and
curate actually respect acquisitions that contain '_ignore-BIDS'